### PR TITLE
Make landmark depth match LH

### DIFF
--- a/Landmark.gd
+++ b/Landmark.gd
@@ -40,8 +40,8 @@ func instance_from_json(json):
 				factor /= 100
 				factor = factor*factor
 				depthFactor = factor
-				# motion_scale = Vector2(factor,factor)
-				motion_scale = Vector2(json[key],json[key])
+			elif key == "rot":
+				rotation_degrees = -json.rot
 			#ToDo: implement motion
 		else:
 			print("PROPERTY NOT KNOWN: " + key)

--- a/Landmark.gd
+++ b/Landmark.gd
@@ -1,16 +1,16 @@
-extends ParallaxLayer
-
-onready var landmark_sprite := $AnimatedSprite
-
+extends AnimatedSprite
 
 var x := 0
 var y := 0
 var xsp := 0
 var elId := 0 # ID of the landmark graphics
 var rot := 0 # rotation
-var dep := 0 # "depth" = scrolling
+var dep := 0 # "depth" = parallax
+var depthFactor: float = 0 # 0 menas attached to world, 1 means attached to camera
 var rsp := 0 # rotation speed
 var sc := 1 # scale
+var world_pos := Vector2.ZERO
+var world_scale : = Vector2.ONE
 
 const dict_base := {
 	"x":0,
@@ -25,15 +25,24 @@ const dict_base := {
 
 func instance_from_json(json):
 	if "x" in json and "y" in json:
-		position = Vector2(json.x, json.y)
+		world_pos = Vector2(json.x, json.y)
 	for key in json.keys():
 		if key in self:
 			self[key] = json[key]
 			if key == "sc":
-				scale = Vector2(json[key],json[key])
+				world_scale = Vector2(json[key],json[key])
 			elif key == "dep":
+				# landmarks with higher depth appear behind those with lower depth in LH
+				z_index = 100 - json.dep
+				# put it behind level nodes & co
+				z_index -= 100
+				var factor := json.dep as float
+				factor /= 100
+				factor = factor*factor
+				depthFactor = factor
+				# motion_scale = Vector2(factor,factor)
 				motion_scale = Vector2(json[key],json[key])
-			#ToDo: implement rotation and shaking
+			#ToDo: implement motion
 		else:
 			print("PROPERTY NOT KNOWN: " + key)
 
@@ -46,4 +55,26 @@ func to_dict() -> Dictionary:
 	return dict_out
 
 func _ready():
-	landmark_sprite.play(String(elId))
+	play(String(elId))
+	
+func _process(_delta):
+	var cam = getCurrentCamera2D()
+	if not cam:
+		return
+	var cam_pos = cam.global_position + world_pos
+	position = lerp(world_pos, cam_pos, depthFactor)
+	var cam_scale = world_scale * cam.zoom
+	scale = lerp(world_scale, cam_scale, depthFactor)
+
+# Godot why
+# It's in 4, and there's a PR to bring it to 3 https://github.com/godotengine/godot/pull/69426
+func getCurrentCamera2D() -> Camera2D:
+	var viewport = get_viewport()
+	if not viewport:
+		return null
+	var camerasGroupName = "__cameras_%d" % viewport.get_viewport_rid().get_id()
+	var cameras = get_tree().get_nodes_in_group(camerasGroupName)
+	for camera in cameras:
+		if camera is Camera2D and camera.current:
+			return camera
+	return null

--- a/Landmark.tscn
+++ b/Landmark.tscn
@@ -138,9 +138,7 @@ animations = [ {
 "speed": 5.0
 } ]
 
-[node name="Landmark" type="ParallaxLayer"]
-script = ExtResource( 24 )
-
-[node name="AnimatedSprite" type="AnimatedSprite" parent="."]
+[node name="AnimatedSprite" type="AnimatedSprite"]
 frames = SubResource( 1 )
 animation = "1"
+script = ExtResource( 24 )

--- a/LandmarkManager.gd
+++ b/LandmarkManager.gd
@@ -1,4 +1,4 @@
-extends ParallaxBackground
+extends Node2D
 
 var Landmark := load("res://Landmark.tscn")
 

--- a/MapEditor.tscn
+++ b/MapEditor.tscn
@@ -39,8 +39,7 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 texture = ExtResource( 1 )
 
-[node name="LandmarkManager" type="ParallaxBackground" parent="."]
-layer = -1
+[node name="LandmarkManager" type="Node2D" parent="."]
 script = ExtResource( 18 )
 
 [node name="Connections" type="Node2D" parent="."]

--- a/SavedCampaigns/Saved/UC_test_landmarks.json
+++ b/SavedCampaigns/Saved/UC_test_landmarks.json
@@ -1,0 +1,218 @@
+{
+	"creatorName": "Definitely Radio",
+	"creatorCode": "fck11l",
+	"campaignName": "Landmarks test",
+	"version": 1,
+	"mapNodes": [
+		{
+			"t": 0,
+			"ch": 0,
+			"gr18": 0,
+			"b_time": 0,
+			"pre_all": 0,
+			"pre_gr18": 0,
+			"pre_coin": 0,
+			"pre_chall": 0,
+			"pre": [],
+			"n": "LEVEL 1",
+			"x": 50,
+			"y": 50,
+			"weather": 0,
+			"main": 0,
+			"bm": 0,
+			"sc": 0,
+			"scpre": 0,
+			"scpost": 0,
+			"levelID": "lsdmv1t",
+			"level_completed": true,
+			"level_all_jems": true,
+			"level_found_gr17": true,
+			"level_all_bug_pieces": true
+		},
+		{
+			"t": 0,
+			"ch": 0,
+			"gr18": 0,
+			"b_time": 0,
+			"pre_all": 0,
+			"pre_gr18": 0,
+			"pre_coin": 0,
+			"pre_chall": 0,
+			"pre": [
+				"lsdmv1t"
+			],
+			"n": "LEVEL 2",
+			"x": 900,
+			"y": 500,
+			"weather": 0,
+			"main": 0,
+			"bm": 0,
+			"sc": 0,
+			"scpre": 0,
+			"scpost": 0,
+			"levelID": "bc87xnf",
+			"level_completed": true,
+			"level_all_jems": true,
+			"level_found_gr17": true,
+			"level_all_bug_pieces": true
+		}
+	],
+	"landmarks": [
+		{
+			"elId": 7,
+			"y": -31,
+			"rot": 7,
+			"x": 3470,
+			"dep": 0
+		},
+		{
+			"elId": 14,
+			"y": 497,
+			"rot": 8,
+			"x": 851,
+			"dep": 0
+		},
+		{
+			"elId": 3,
+			"y": -9,
+			"rot": -13,
+			"x": 1369,
+			"dep": 0
+		},
+		{
+			"elId": 19,
+			"y": 574,
+			"rot": 5,
+			"x": 2.5550000009095e25,
+			"dep": 0
+		},
+		{
+			"elId": 10,
+			"y": 445,
+			"rot": 6,
+			"x": -162,
+			"dep": 0
+		},
+		{
+			"elId": 1,
+			"y": 30,
+			"rot": -7,
+			"x": 620,
+			"dep": 0
+		},
+		{
+			"elId": 13,
+			"y": 497,
+			"rot": -4,
+			"x": 493,
+			"dep": 0
+		},
+		{
+			"elId": 18,
+			"y": 569,
+			"rot": -20,
+			"x": 2269,
+			"dep": 0
+		},
+		{
+			"elId": 9,
+			"y": -16,
+			"rot": -3,
+			"x": 4088,
+			"dep": 0
+		},
+		{
+			"elId": 6,
+			"y": 51,
+			"rot": -9,
+			"x": 2873,
+			"dep": 0
+		},
+		{
+			"elId": 15,
+			"y": 570,
+			"rot": -2,
+			"x": 1.2250000009095e25,
+			"dep": 0
+		},
+		{
+			"elId": 11,
+			"y": 431,
+			"rot": 0,
+			"x": 6,
+			"dep": 0
+		},
+		{
+			"elId": 16,
+			"y": 554,
+			"rot": 13,
+			"x": 1.5390000009095e25,
+			"dep": 0
+		},
+		{
+			"elId": 4,
+			"y": -76,
+			"rot": -11,
+			"x": 2054,
+			"dep": 0
+		},
+		{
+			"elId": 2,
+			"y": 94,
+			"rot": -10,
+			"x": 887,
+			"dep": 0
+		},
+		{
+			"elId": 17,
+			"y": 0,
+			"rot": -13,
+			"x": 0,
+			"dep": 70
+		},
+		{
+			"elId": 17,
+			"y": 539,
+			"rot": 0,
+			"x": 1927,
+			"dep": 0
+		},
+		{
+			"1": 0,
+			"elId": 0,
+			"sc": 1,
+			"2": 1000,
+			"x": 275,
+			"dep": 0
+		},
+		{
+			"elId": 5,
+			"y": -542,
+			"rot": -7,
+			"x": 2768,
+			"dep": 0
+		},
+		{
+			"y": 0,
+			"elId": 16,
+			"sc": 2,
+			"rot": -10,
+			"x": 0,
+			"dep": 40
+		},
+		{
+			"elId": 12,
+			"y": 400,
+			"rot": 12,
+			"x": 250,
+			"dep": 0
+		},
+		{
+			"elId": 8,
+			"y": 19,
+			"rot": -10,
+			"x": 3900,
+			"dep": 0
+		}
+	]
+}

--- a/Util.gd
+++ b/Util.gd
@@ -67,6 +67,9 @@ func get_files_that_match_uc(folder : String):
 			file_buf.close()
 			if campaign_out.error == OK:
 				files.append(campaign_out.result)
+			else:
+				printerr("Error %d while parsing %s at line %d:" % [campaign_out.error, file, campaign_out.error_line])
+				printerr(campaign_out.error_string)
 	
 	dir.list_dir_end()
 	


### PR DESCRIPTION
Reworks landmarks to no longer use parallax layers, but a simple Node2D and AnimatedSprites that get moved and scaled manually. (I couldn't get it to work with the ParallaxBackground).
As far as I can tell this now looks about the same as LH.
Something more integrated with Godot might be possible by using the Follow Viewport Scale of a CanvasLayer, but this was already enough fiddling.

This PR also adds landmark rotation and some logging of parse errors because I ran into that.